### PR TITLE
Fix coc contacts email link

### DIFF
--- a/online/english.md
+++ b/online/english.md
@@ -46,5 +46,5 @@ We expect all the users to follow these rules on any online presence of Python I
 Shall you need a personal private conversation with the admin or you can't find the right contacts for a specific online presence of Python Italia, please contact
 one of the following people:
 
-Francesca Zerlotti [mailto:francesca@python.it](francesca@python.it)
-Matteo Benci [mailto:matteo@python.it](matteo@python.it)
+Francesca Zerlotti [francesca@python.it](mailto:francesca@python.it)
+Matteo Benci [matteo@python.it](mailto:matteo@python.it)

--- a/online/italian.md
+++ b/online/italian.md
@@ -46,5 +46,5 @@ Python Italia.
 
 Doveste aver bisogno di parlare privatamente con gli organizzatori, contattate una delle seguenti persone:
 
-Francesca Zerlotti [mailto:francesca@python.it](francesca@python.it)
-Matteo Benci [mailto:matteo@python.it](matteo@python.it)
+Francesca Zerlotti [francesca@python.it](mailto:francesca@python.it)
+Matteo Benci [matteo@python.it](mailto:matteo@python.it)


### PR DESCRIPTION
Right now when you click on a contact email it doesn't open the mail page (the result is a 404 page)

To see the result: 

https://github.com/marcoacierno/code-of-conducts/blob/fix/email-links/online/italian.md
https://github.com/marcoacierno/code-of-conducts/blob/fix/email-links/online/english.md